### PR TITLE
Add the ability to copy the produced image to the clipboard automatically

### DIFF
--- a/lua/freeze/init.lua
+++ b/lua/freeze/init.lua
@@ -3,8 +3,9 @@ local default_output = "freeze.png"
 
 local freeze = {
 	opts = {
+		dir = ".",
 		output = default_output,
-		config = "full",
+		config = "base",
 		open = false,
 	},
 	output = nil,

--- a/lua/freeze/init.lua
+++ b/lua/freeze/init.lua
@@ -3,6 +3,7 @@ local default_output = "freeze.png"
 
 local freeze = {
 	opts = {
+		dir = ".",
 		output = default_output,
 		config = "full",
 		open = false,

--- a/lua/freeze/init.lua
+++ b/lua/freeze/init.lua
@@ -3,13 +3,13 @@ local loop = vim.loop
 local home = os.getenv("HOME")
 
 local freeze = {
-    opts = {
-        config = "full",
-        dir = home .. "/.config/freeze",
-        prefix = "freze-{file}",
-        open = false,
-    },
-    output = nil,
+	opts = {
+		config = "full",
+		dir = home .. "/.config/freeze",
+		prefix = "freze-{file}",
+		open = false,
+	},
+	output = nil,
 }
 local output = { stdout = "", stderr = "" }
 
@@ -17,28 +17,28 @@ local output = { stdout = "", stderr = "" }
 ---@param err any the possible err we received
 ---@param data any the possible data we received in stdout
 local function onReadStdOut(err, data)
-    if err then
-        vim.notify(err, vim.log.levels.ERROR, { title = "Freeze" })
-    end
-    if data then
-        output.stdout = output.stdout .. data
-    end
-    if freeze.opts.open and freeze.output ~= nil then
-        freeze.open(freeze.output)
-        freeze.output = nil
-    end
+	if err then
+		vim.notify(err, vim.log.levels.ERROR, { title = "Freeze" })
+	end
+	if data then
+		output.stdout = output.stdout .. data
+	end
+	if freeze.opts.open and freeze.output ~= nil then
+		freeze.open(freeze.output)
+		freeze.output = nil
+	end
 end
 
 ---The callback for reading stderr.
 ---@param err any the possible err we received
 ---@param data any the possible data we received in stderr
 local function onReadStdErr(err, data)
-    if err then
-        vim.notify(err, vim.log.levels.ERROR, { title = "Freeze" })
-    end
-    if data then
-        output.stderr = output.stderr .. data
-    end
+	if err then
+		vim.notify(err, vim.log.levels.ERROR, { title = "Freeze" })
+	end
+	if data then
+		output.stderr = output.stderr .. data
+	end
 end
 
 ---The function called on exit of from the event loop
@@ -46,17 +46,17 @@ end
 ---@param stderr any the stderr pipe used by vim.loop
 ---@return function cb the wrapped schedule function callback
 local function onExit(stdout, stderr)
-    return vim.schedule_wrap(function(code, _)
-        if code == 0 then
-            vim.notify("Successfully frozen 🍦", vim.log.levels.INFO, { title = "Freeze" })
-        else
-            vim.notify(output.stdout, vim.log.levels.ERROR, { title = "Freeze" })
-        end
-        stdout:read_stop()
-        stderr:read_stop()
-        stdout:close()
-        stderr:close()
-    end)
+	return vim.schedule_wrap(function(code, _)
+		if code == 0 then
+			vim.notify("Successfully frozen 🍦", vim.log.levels.INFO, { title = "Freeze" })
+		else
+			vim.notify(output.stdout, vim.log.levels.ERROR, { title = "Freeze" })
+		end
+		stdout:read_stop()
+		stderr:read_stop()
+		stdout:close()
+		stderr:close()
+	end)
 end
 
 --- The main function used for passing the main config to lua
@@ -66,97 +66,97 @@ end
 --- @param start_line number the starting line to pass to freeze
 --- @param end_line number the ending line to pass to freeze
 function freeze.freeze(start_line, end_line)
-    if vim.fn.executable("freeze") ~= 1 then
-        vim.notify("`freeze` not found!", vim.log.levels.WARN, { title = "Freeze" })
-        return
-    end
+	if vim.fn.executable("freeze") ~= 1 then
+		vim.notify("`freeze` not found!", vim.log.levels.WARN, { title = "Freeze" })
+		return
+	end
 
-    -- Check if start_line and end_line are provided, otherwise use the visual selection
-    if not start_line or not end_line then
-        local startPos = vim.fn.getpos("'<")
-        local endPos = vim.fn.getpos("'>")
-        start_line = startPos[2] -- Line number of the start of the visual selection
-        end_line = endPos[2] -- Line number of the end of the visual selection
-    end
+	-- Check if start_line and end_line are provided, otherwise use the visual selection
+	if not start_line or not end_line then
+		local startPos = vim.fn.getpos("'<")
+		local endPos = vim.fn.getpos("'>")
+		start_line = startPos[2] -- Line number of the start of the visual selection
+		end_line = endPos[2] -- Line number of the end of the visual selection
+	end
 
-    local language = vim.api.nvim_buf_get_option(0, "filetype")
-    local file = vim.api.nvim_buf_get_name(0)
-    local prefix = freeze.opts.prefix
-    local dir = freeze.opts.dir
-    local timestamp = os.date("%Y%m%d%H%M%S")
-    local filename = file:match("^.+/(.+)$") or file
-    local modified_prefix = prefix:gsub("{file}", filename)
-    freeze.output = dir .. "/" .. modified_prefix .. "-" .. timestamp .. ".png"
-    local stdout = loop.new_pipe(false)
-    local stderr = loop.new_pipe(false)
-    local handle = loop.spawn("freeze", {
-        args = {
-            "--output",
-            freeze.output,
-            "--language",
-            language,
-            "--lines",
-            start_line .. "," .. end_line,
-            "--config",
-            freeze.opts.config,
-            file,
-        },
-        stdio = { nil, stdout, stderr },
-    }, onExit(stdout, stderr))
-    if not handle then
-        vim.notify("Failed to spawn freeze", vim.log.levels.ERROR, { title = "Freeze" })
-    end
-    if stdout ~= nil then
-        loop.read_start(stdout, onReadStdOut)
-    end
-    if stderr ~= nil then
-        loop.read_start(stderr, onReadStdErr)
-    end
+	local language = vim.api.nvim_buf_get_option(0, "filetype")
+	local file = vim.api.nvim_buf_get_name(0)
+	local prefix = freeze.opts.prefix
+	local dir = freeze.opts.dir
+	local timestamp = os.date("%Y%m%d%H%M%S")
+	local filename = file:match("^.+/(.+)$") or file
+	local modified_prefix = prefix:gsub("{file}", filename)
+	freeze.output = dir .. "/" .. modified_prefix .. "-" .. timestamp .. ".png"
+	local stdout = loop.new_pipe(false)
+	local stderr = loop.new_pipe(false)
+	local handle = loop.spawn("freeze", {
+		args = {
+			"--output",
+			freeze.output,
+			"--language",
+			language,
+			"--lines",
+			start_line .. "," .. end_line,
+			"--config",
+			freeze.opts.config,
+			file,
+		},
+		stdio = { nil, stdout, stderr },
+	}, onExit(stdout, stderr))
+	if not handle then
+		vim.notify("Failed to spawn freeze", vim.log.levels.ERROR, { title = "Freeze" })
+	end
+	if stdout ~= nil then
+		loop.read_start(stdout, onReadStdOut)
+	end
+	if stderr ~= nil then
+		loop.read_start(stderr, onReadStdErr)
+	end
 end
 
 function freeze.open(filename)
-    if vim.fn.executable("open") ~= 1 then
-        vim.notify("`freeze` not found!", vim.log.levels.WARN, { title = "Freeze" })
-        return
-    end
+	if vim.fn.executable("open") ~= 1 then
+		vim.notify("`freeze` not found!", vim.log.levels.WARN, { title = "Freeze" })
+		return
+	end
 
-    local stdout = loop.new_pipe(false)
-    local stderr = loop.new_pipe(false)
-    local handle = loop.spawn("open", {
-        args = {
-            filename,
-        },
-        stdio = { nil, stdout, stderr },
-    }, onExit(stdout, stderr))
-    if not handle then
-        vim.notify("Failed to spawn freeze", vim.log.levels.ERROR, { title = "Freeze" })
-    end
-    if stdout ~= nil then
-        loop.read_start(stdout, onReadStdOut)
-    end
-    if stderr ~= nil then
-        loop.read_start(stderr, onReadStdErr)
-    end
+	local stdout = loop.new_pipe(false)
+	local stderr = loop.new_pipe(false)
+	local handle = loop.spawn("open", {
+		args = {
+			filename,
+		},
+		stdio = { nil, stdout, stderr },
+	}, onExit(stdout, stderr))
+	if not handle then
+		vim.notify("Failed to spawn freeze", vim.log.levels.ERROR, { title = "Freeze" })
+	end
+	if stdout ~= nil then
+		loop.read_start(stdout, onReadStdOut)
+	end
+	if stderr ~= nil then
+		loop.read_start(stderr, onReadStdErr)
+	end
 end
 
 --- Setup function for enabling both user commands.
 --- Sets up :Freeze for freezing a selection and :FreezeLine
 --- to freeze a single line.
 function freeze.setup(plugin_opts)
-    for k, v in pairs(plugin_opts) do
-        freeze.opts[k] = v
-    end
-    vim.api.nvim_create_user_command("Freeze", function(opts)
-        if opts.count > 0 then
-            freeze.freeze(opts.line1, opts.line2)
-        else
-            freeze.freeze(1, vim.api.nvim_buf_line_count(0))
-        end
-    end, { range = true })
-    vim.api.nvim_create_user_command("FreezeLine", function(_)
-        local line = vim.api.nvim_win_get_cursor(0)[1]
-        freeze.freeze(line, line)
-    end, {})
+	for k, v in pairs(plugin_opts) do
+		freeze.opts[k] = v
+	end
+	vim.api.nvim_create_user_command("Freeze", function(opts)
+		if opts.count > 0 then
+			freeze.freeze(opts.line1, opts.line2)
+		else
+			freeze.freeze(1, vim.api.nvim_buf_line_count(0))
+		end
+	end, { range = true })
+	vim.api.nvim_create_user_command("FreezeLine", function(_)
+		local line = vim.api.nvim_win_get_cursor(0)[1]
+		freeze.freeze(line, line)
+	end, {})
 end
 
 return freeze

--- a/lua/freeze/init.lua
+++ b/lua/freeze/init.lua
@@ -1,17 +1,15 @@
 local loop = vim.loop
-
-local home = os.getenv("HOME")
+local default_output = "freeze.png"
 
 local freeze = {
 	opts = {
+		output = default_output,
 		config = "full",
-		dir = home .. "/.config/freeze",
-		prefix = "freze-{file}",
 		open = false,
 	},
 	output = nil,
 }
-local output = { stdout = "", stderr = "" }
+local stdio = { stdout = "", stderr = "" }
 
 ---The callback for reading stdout.
 ---@param err any the possible err we received
@@ -21,7 +19,7 @@ local function onReadStdOut(err, data)
 		vim.notify(err, vim.log.levels.ERROR, { title = "Freeze" })
 	end
 	if data then
-		output.stdout = output.stdout .. data
+		stdio.stdout = stdio.stdout .. data
 	end
 	if freeze.opts.open and freeze.output ~= nil then
 		freeze.open(freeze.output)
@@ -37,7 +35,7 @@ local function onReadStdErr(err, data)
 		vim.notify(err, vim.log.levels.ERROR, { title = "Freeze" })
 	end
 	if data then
-		output.stderr = output.stderr .. data
+		stdio.stderr = stdio.stderr .. data
 	end
 end
 
@@ -50,7 +48,7 @@ local function onExit(stdout, stderr)
 		if code == 0 then
 			vim.notify("Successfully frozen 🍦", vim.log.levels.INFO, { title = "Freeze" })
 		else
-			vim.notify(output.stdout, vim.log.levels.ERROR, { title = "Freeze" })
+			vim.notify(stdio.stdout, vim.log.levels.ERROR, { title = "Freeze" })
 		end
 		stdout:read_stop()
 		stderr:read_stop()
@@ -71,24 +69,26 @@ function freeze.freeze(start_line, end_line)
 		return
 	end
 
-	-- Check if start_line and end_line are provided, otherwise use the visual selection
-	if not start_line or not end_line then
-		local startPos = vim.fn.getpos("'<")
-		local endPos = vim.fn.getpos("'>")
-		start_line = startPos[2] -- Line number of the start of the visual selection
-		end_line = endPos[2] -- Line number of the end of the visual selection
-	end
-
 	local language = vim.api.nvim_buf_get_option(0, "filetype")
 	local file = vim.api.nvim_buf_get_name(0)
-	local prefix = freeze.opts.prefix
+	local config = freeze.opts.config
 	local dir = freeze.opts.dir
-	local timestamp = os.date("%Y%m%d%H%M%S")
-	local filename = file:match("^.+/(.+)$") or file
-	local modified_prefix = prefix:gsub("{file}", filename)
-	freeze.output = dir .. "/" .. modified_prefix .. "-" .. timestamp .. ".png"
 	local stdout = loop.new_pipe(false)
 	local stderr = loop.new_pipe(false)
+	local output = freeze.opts.output
+
+	if freeze.opts.output ~= default_output then
+		local timestamp = os.date("%Y%m%d%H%M%S")
+		local filename = file:match("^.+/(.+)$") or file
+
+		output = output:gsub("{timestamp}", timestamp)
+		output = output:gsub("{filename}", filename)
+		output = output:gsub("{start_line}", start_line)
+		output = output:gsub("{end_line}", end_line)
+	end
+
+	freeze.output = dir .. "/" .. output
+
 	local handle = loop.spawn("freeze", {
 		args = {
 			"--output",
@@ -98,7 +98,7 @@ function freeze.freeze(start_line, end_line)
 			"--lines",
 			start_line .. "," .. end_line,
 			"--config",
-			freeze.opts.config,
+			config,
 			file,
 		},
 		stdio = { nil, stdout, stderr },

--- a/lua/freeze/init.lua
+++ b/lua/freeze/init.lua
@@ -3,13 +3,13 @@ local loop = vim.loop
 local home = os.getenv("HOME")
 
 local freeze = {
-  opts = {
-    config = "full",
-    dir = home .. "/.config/freeze",
-    prefix = "freze-{file}",
-    open = false,
-  },
-  output = nil,
+    opts = {
+        config = "full",
+        dir = home .. "/.config/freeze",
+        prefix = "freze-{file}",
+        open = false,
+    },
+    output = nil,
 }
 local output = { stdout = "", stderr = "" }
 
@@ -17,28 +17,28 @@ local output = { stdout = "", stderr = "" }
 ---@param err any the possible err we received
 ---@param data any the possible data we received in stdout
 local function onReadStdOut(err, data)
-  if err then
-    vim.notify(err, vim.log.levels.ERROR, { title = "Freeze" })
-  end
-  if data then
-    output.stdout = output.stdout .. data
-  end
-  if freeze.opts.open and freeze.output ~= nil then
-    freeze.open(freeze.output)
-    freeze.output = nil
-  end
+    if err then
+        vim.notify(err, vim.log.levels.ERROR, { title = "Freeze" })
+    end
+    if data then
+        output.stdout = output.stdout .. data
+    end
+    if freeze.opts.open and freeze.output ~= nil then
+        freeze.open(freeze.output)
+        freeze.output = nil
+    end
 end
 
 ---The callback for reading stderr.
 ---@param err any the possible err we received
 ---@param data any the possible data we received in stderr
 local function onReadStdErr(err, data)
-  if err then
-    vim.notify(err, vim.log.levels.ERROR, { title = "Freeze" })
-  end
-  if data then
-    output.stderr = output.stderr .. data
-  end
+    if err then
+        vim.notify(err, vim.log.levels.ERROR, { title = "Freeze" })
+    end
+    if data then
+        output.stderr = output.stderr .. data
+    end
 end
 
 ---The function called on exit of from the event loop
@@ -46,17 +46,17 @@ end
 ---@param stderr any the stderr pipe used by vim.loop
 ---@return function cb the wrapped schedule function callback
 local function onExit(stdout, stderr)
-  return vim.schedule_wrap(function(code, _)
-    if code == 0 then
-      vim.notify("Successfully frozen 🍦", vim.log.levels.INFO, { title = "Freeze" })
-    else
-      vim.notify(output.stdout, vim.log.levels.ERROR, { title = "Freeze" })
-    end
-    stdout:read_stop()
-    stderr:read_stop()
-    stdout:close()
-    stderr:close()
-  end)
+    return vim.schedule_wrap(function(code, _)
+        if code == 0 then
+            vim.notify("Successfully frozen 🍦", vim.log.levels.INFO, { title = "Freeze" })
+        else
+            vim.notify(output.stdout, vim.log.levels.ERROR, { title = "Freeze" })
+        end
+        stdout:read_stop()
+        stderr:read_stop()
+        stdout:close()
+        stderr:close()
+    end)
 end
 
 --- The main function used for passing the main config to lua
@@ -66,97 +66,97 @@ end
 --- @param start_line number the starting line to pass to freeze
 --- @param end_line number the ending line to pass to freeze
 function freeze.freeze(start_line, end_line)
-  if vim.fn.executable("freeze") ~= 1 then
-    vim.notify("`freeze` not found!", vim.log.levels.WARN, { title = "Freeze" })
-    return
-  end
+    if vim.fn.executable("freeze") ~= 1 then
+        vim.notify("`freeze` not found!", vim.log.levels.WARN, { title = "Freeze" })
+        return
+    end
 
-  -- Check if start_line and end_line are provided, otherwise use the visual selection
-  if not start_line or not end_line then
-    local startPos = vim.fn.getpos("'<")
-    local endPos = vim.fn.getpos("'>")
-    start_line = startPos[2] -- Line number of the start of the visual selection
-    end_line = endPos[2] -- Line number of the end of the visual selection
-  end
+    -- Check if start_line and end_line are provided, otherwise use the visual selection
+    if not start_line or not end_line then
+        local startPos = vim.fn.getpos("'<")
+        local endPos = vim.fn.getpos("'>")
+        start_line = startPos[2] -- Line number of the start of the visual selection
+        end_line = endPos[2] -- Line number of the end of the visual selection
+    end
 
-  local language = vim.api.nvim_buf_get_option(0, "filetype")
-  local file = vim.api.nvim_buf_get_name(0)
-  local prefix = freeze.opts.prefix
-  local dir = freeze.opts.dir
-  local timestamp = os.date("%Y%m%d%H%M%S")
-  local filename = file:match("^.+/(.+)$") or file
-  local modified_prefix = prefix:gsub("{file}", filename)
-  freeze.output = dir .. "/" .. modified_prefix .. "-" .. timestamp .. ".png"
-  local stdout = loop.new_pipe(false)
-  local stderr = loop.new_pipe(false)
-  local handle = loop.spawn("freeze", {
-    args = {
-      "--output",
-      freeze.output,
-      "--language",
-      language,
-      "--lines",
-      start_line .. "," .. end_line,
-      "--config",
-      freeze.opts.config,
-      file,
-    },
-    stdio = { nil, stdout, stderr },
-  }, onExit(stdout, stderr))
-  if not handle then
-    vim.notify("Failed to spawn freeze", vim.log.levels.ERROR, { title = "Freeze" })
-  end
-  if stdout ~= nil then
-    loop.read_start(stdout, onReadStdOut)
-  end
-  if stderr ~= nil then
-    loop.read_start(stderr, onReadStdErr)
-  end
+    local language = vim.api.nvim_buf_get_option(0, "filetype")
+    local file = vim.api.nvim_buf_get_name(0)
+    local prefix = freeze.opts.prefix
+    local dir = freeze.opts.dir
+    local timestamp = os.date("%Y%m%d%H%M%S")
+    local filename = file:match("^.+/(.+)$") or file
+    local modified_prefix = prefix:gsub("{file}", filename)
+    freeze.output = dir .. "/" .. modified_prefix .. "-" .. timestamp .. ".png"
+    local stdout = loop.new_pipe(false)
+    local stderr = loop.new_pipe(false)
+    local handle = loop.spawn("freeze", {
+        args = {
+            "--output",
+            freeze.output,
+            "--language",
+            language,
+            "--lines",
+            start_line .. "," .. end_line,
+            "--config",
+            freeze.opts.config,
+            file,
+        },
+        stdio = { nil, stdout, stderr },
+    }, onExit(stdout, stderr))
+    if not handle then
+        vim.notify("Failed to spawn freeze", vim.log.levels.ERROR, { title = "Freeze" })
+    end
+    if stdout ~= nil then
+        loop.read_start(stdout, onReadStdOut)
+    end
+    if stderr ~= nil then
+        loop.read_start(stderr, onReadStdErr)
+    end
 end
 
 function freeze.open(filename)
-  if vim.fn.executable("open") ~= 1 then
-    vim.notify("`freeze` not found!", vim.log.levels.WARN, { title = "Freeze" })
-    return
-  end
+    if vim.fn.executable("open") ~= 1 then
+        vim.notify("`freeze` not found!", vim.log.levels.WARN, { title = "Freeze" })
+        return
+    end
 
-  local stdout = loop.new_pipe(false)
-  local stderr = loop.new_pipe(false)
-  local handle = loop.spawn("open", {
-    args = {
-      filename,
-    },
-    stdio = { nil, stdout, stderr },
-  }, onExit(stdout, stderr))
-  if not handle then
-    vim.notify("Failed to spawn freeze", vim.log.levels.ERROR, { title = "Freeze" })
-  end
-  if stdout ~= nil then
-    loop.read_start(stdout, onReadStdOut)
-  end
-  if stderr ~= nil then
-    loop.read_start(stderr, onReadStdErr)
-  end
+    local stdout = loop.new_pipe(false)
+    local stderr = loop.new_pipe(false)
+    local handle = loop.spawn("open", {
+        args = {
+            filename,
+        },
+        stdio = { nil, stdout, stderr },
+    }, onExit(stdout, stderr))
+    if not handle then
+        vim.notify("Failed to spawn freeze", vim.log.levels.ERROR, { title = "Freeze" })
+    end
+    if stdout ~= nil then
+        loop.read_start(stdout, onReadStdOut)
+    end
+    if stderr ~= nil then
+        loop.read_start(stderr, onReadStdErr)
+    end
 end
 
 --- Setup function for enabling both user commands.
 --- Sets up :Freeze for freezing a selection and :FreezeLine
 --- to freeze a single line.
 function freeze.setup(plugin_opts)
-  for k, v in pairs(plugin_opts) do
-    freeze.opts[k] = v
-  end
-  vim.api.nvim_create_user_command("Freeze", function(opts)
-    if opts.count > 0 then
-      freeze.freeze(opts.line1, opts.line2)
-    else
-      freeze.freeze(1, vim.api.nvim_buf_line_count(0))
+    for k, v in pairs(plugin_opts) do
+        freeze.opts[k] = v
     end
-  end, { range = true })
-  vim.api.nvim_create_user_command("FreezeLine", function(_)
-    local line = vim.api.nvim_win_get_cursor(0)[1]
-    freeze.freeze(line, line)
-  end, {})
+    vim.api.nvim_create_user_command("Freeze", function(opts)
+        if opts.count > 0 then
+            freeze.freeze(opts.line1, opts.line2)
+        else
+            freeze.freeze(1, vim.api.nvim_buf_line_count(0))
+        end
+    end, { range = true })
+    vim.api.nvim_create_user_command("FreezeLine", function(_)
+        local line = vim.api.nvim_win_get_cursor(0)[1]
+        freeze.freeze(line, line)
+    end, {})
 end
 
 return freeze

--- a/lua/freeze/init.lua
+++ b/lua/freeze/init.lua
@@ -1,29 +1,44 @@
 local loop = vim.loop
-local freeze = {}
+
+local home = os.getenv("HOME")
+
+local freeze = {
+  opts = {
+    config = "full",
+    dir = home .. "/.config/freeze",
+    prefix = "freze-{file}",
+    open = false,
+  },
+  output = nil,
+}
 local output = { stdout = "", stderr = "" }
 
 ---The callback for reading stdout.
 ---@param err any the possible err we received
 ---@param data any the possible data we received in stdout
 local function onReadStdOut(err, data)
-	if err then
-		vim.notify(err, vim.log.levels.ERROR, { title = "Freeze" })
-	end
-	if data then
-		output.stdout = output.stdout .. data
-	end
+  if err then
+    vim.notify(err, vim.log.levels.ERROR, { title = "Freeze" })
+  end
+  if data then
+    output.stdout = output.stdout .. data
+  end
+  if freeze.opts.open and freeze.output ~= nil then
+    freeze.open(freeze.output)
+    freeze.output = nil
+  end
 end
 
 ---The callback for reading stderr.
 ---@param err any the possible err we received
 ---@param data any the possible data we received in stderr
 local function onReadStdErr(err, data)
-	if err then
-		vim.notify(err, vim.log.levels.ERROR, { title = "Freeze" })
-	end
-	if data then
-		output.stderr = output.stderr .. data
-	end
+  if err then
+    vim.notify(err, vim.log.levels.ERROR, { title = "Freeze" })
+  end
+  if data then
+    output.stderr = output.stderr .. data
+  end
 end
 
 ---The function called on exit of from the event loop
@@ -31,17 +46,17 @@ end
 ---@param stderr any the stderr pipe used by vim.loop
 ---@return function cb the wrapped schedule function callback
 local function onExit(stdout, stderr)
-	return vim.schedule_wrap(function(code, _)
-		if code == 0 then
-			vim.notify("Successfully frozen 🍦", vim.log.levels.INFO, { title = "Freeze" })
-		else
-			vim.notify(output.stdout, vim.log.levels.ERROR, { title = "Freeze" })
-		end
-		stdout:read_stop()
-		stderr:read_stop()
-		stdout:close()
-		stderr:close()
-	end)
+  return vim.schedule_wrap(function(code, _)
+    if code == 0 then
+      vim.notify("Successfully frozen 🍦", vim.log.levels.INFO, { title = "Freeze" })
+    else
+      vim.notify(output.stdout, vim.log.levels.ERROR, { title = "Freeze" })
+    end
+    stdout:read_stop()
+    stderr:read_stop()
+    stdout:close()
+    stderr:close()
+  end)
 end
 
 --- The main function used for passing the main config to lua
@@ -51,40 +66,97 @@ end
 --- @param start_line number the starting line to pass to freeze
 --- @param end_line number the ending line to pass to freeze
 function freeze.freeze(start_line, end_line)
-	if vim.fn.executable("freeze") ~= 1 then
-		vim.notify("`freeze` not found!", vim.log.levels.WARN, { title = "Freeze" })
-		return
-	end
-	local language = vim.api.nvim_buf_get_option(0, "filetype")
-	local file = vim.api.nvim_buf_get_name(0)
-	local stdout = loop.new_pipe(false)
-	local stderr = loop.new_pipe(false)
-	local handle = loop.spawn("freeze", {
-		args = { "--language", language, "--lines", start_line .. "," .. end_line, file },
-		stdio = { nil, stdout, stderr },
-	}, onExit(stdout, stderr))
-	if not handle then
-		vim.notify("Failed to spawn freeze", vim.log.levels.ERROR, { title = "Freeze" })
-	end
-	loop.read_start(stdout, onReadStdOut)
-	loop.read_start(stderr, onReadStdErr)
+  if vim.fn.executable("freeze") ~= 1 then
+    vim.notify("`freeze` not found!", vim.log.levels.WARN, { title = "Freeze" })
+    return
+  end
+
+  -- Check if start_line and end_line are provided, otherwise use the visual selection
+  if not start_line or not end_line then
+    local startPos = vim.fn.getpos("'<")
+    local endPos = vim.fn.getpos("'>")
+    start_line = startPos[2] -- Line number of the start of the visual selection
+    end_line = endPos[2] -- Line number of the end of the visual selection
+  end
+
+  local language = vim.api.nvim_buf_get_option(0, "filetype")
+  local file = vim.api.nvim_buf_get_name(0)
+  local prefix = freeze.opts.prefix
+  local dir = freeze.opts.dir
+  local timestamp = os.date("%Y%m%d%H%M%S")
+  local filename = file:match("^.+/(.+)$") or file
+  local modified_prefix = prefix:gsub("{file}", filename)
+  freeze.output = dir .. "/" .. modified_prefix .. "-" .. timestamp .. ".png"
+  local stdout = loop.new_pipe(false)
+  local stderr = loop.new_pipe(false)
+  local handle = loop.spawn("freeze", {
+    args = {
+      "--output",
+      freeze.output,
+      "--language",
+      language,
+      "--lines",
+      start_line .. "," .. end_line,
+      "--config",
+      freeze.opts.config,
+      file,
+    },
+    stdio = { nil, stdout, stderr },
+  }, onExit(stdout, stderr))
+  if not handle then
+    vim.notify("Failed to spawn freeze", vim.log.levels.ERROR, { title = "Freeze" })
+  end
+  if stdout ~= nil then
+    loop.read_start(stdout, onReadStdOut)
+  end
+  if stderr ~= nil then
+    loop.read_start(stderr, onReadStdErr)
+  end
+end
+
+function freeze.open(filename)
+  if vim.fn.executable("open") ~= 1 then
+    vim.notify("`freeze` not found!", vim.log.levels.WARN, { title = "Freeze" })
+    return
+  end
+
+  local stdout = loop.new_pipe(false)
+  local stderr = loop.new_pipe(false)
+  local handle = loop.spawn("open", {
+    args = {
+      filename,
+    },
+    stdio = { nil, stdout, stderr },
+  }, onExit(stdout, stderr))
+  if not handle then
+    vim.notify("Failed to spawn freeze", vim.log.levels.ERROR, { title = "Freeze" })
+  end
+  if stdout ~= nil then
+    loop.read_start(stdout, onReadStdOut)
+  end
+  if stderr ~= nil then
+    loop.read_start(stderr, onReadStdErr)
+  end
 end
 
 --- Setup function for enabling both user commands.
 --- Sets up :Freeze for freezing a selection and :FreezeLine
 --- to freeze a single line.
-function freeze.setup()
-	vim.api.nvim_create_user_command("Freeze", function(opts)
-		if opts.count > 0 then
-			freeze.freeze(opts.line1, opts.line2)
-		else
-			freeze.freeze(1, vim.api.nvim_buf_line_count(0))
-		end
-	end, { range = true })
-	vim.api.nvim_create_user_command("FreezeLine", function(opts)
-		local line = vim.api.nvim_win_get_cursor(0)[1]
-		freeze.freeze(line, line)
-	end, {})
+function freeze.setup(plugin_opts)
+  for k, v in pairs(plugin_opts) do
+    freeze.opts[k] = v
+  end
+  vim.api.nvim_create_user_command("Freeze", function(opts)
+    if opts.count > 0 then
+      freeze.freeze(opts.line1, opts.line2)
+    else
+      freeze.freeze(1, vim.api.nvim_buf_line_count(0))
+    end
+  end, { range = true })
+  vim.api.nvim_create_user_command("FreezeLine", function(_)
+    local line = vim.api.nvim_win_get_cursor(0)[1]
+    freeze.freeze(line, line)
+  end, {})
 end
 
 return freeze

--- a/lua/freeze/init.lua
+++ b/lua/freeze/init.lua
@@ -3,7 +3,6 @@ local default_output = "freeze.png"
 
 local freeze = {
 	opts = {
-		dir = ".",
 		output = default_output,
 		config = "full",
 		open = false,
@@ -119,7 +118,7 @@ end
 --- @param filename string the filename to open
 function freeze.open(filename)
 	if vim.fn.executable("open") ~= 1 then
-		vim.notify("`freeze` not found!", vim.log.levels.WARN, { title = "Freeze" })
+		vim.notify("`open` not found!", vim.log.levels.WARN, { title = "Freeze" })
 		return
 	end
 

--- a/lua/freeze/init.lua
+++ b/lua/freeze/init.lua
@@ -114,6 +114,8 @@ function freeze.freeze(start_line, end_line)
 	end
 end
 
+--- Opens the last created image in macOS using `open`.
+--- @param filename string the filename to open
 function freeze.open(filename)
 	if vim.fn.executable("open") ~= 1 then
 		vim.notify("`freeze` not found!", vim.log.levels.WARN, { title = "Freeze" })


### PR DESCRIPTION
This might be too much or too `macOS` oriented, but I'm using it and wanted to share it.

I changed the `open` option to an `action` one that takes two possible values: `open` or `copy`. If you pass the `open`, it will open the image as before, but if you set it to `copy` it will try to load the image to your clipboard using an `osascript` that must be available on the `$PATH` and named `copy`.

Here is what that script should look like:

```bash
#!/usr/bin/env bash

osascript -e{'on run{a}','set the clipboard to posix file a',end} "$(greadlink -f -- "$1")";
```

> I got this from `StackOverflow` and I'm not entirely sure how it works, only that it does.

To simplify things, I added a `warning` message that gets printed if the `copy` command is not set.

This pattern also supports other ways of copying the images, so I prefer it.

I understand if these changes need to be clarified with the project.

![freeze-copy-1_3-20240410133512](https://github.com/ethanholz/freeze.nvim/assets/127410436/dc5da03a-00bf-4252-9a02-151211975d5f)

> Pasting this image here to convince myself that it works :D