### PR TITLE
[Feat]: Added installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # freeze.nvim
+
 A tool for using [freeze](https://github.com/charmbracelet/freeze) right from Neovim!
 
-## Requirements
-- [freeze](https://github.com/charmbracelet/freeze) must be installed and on your path
-
 ## Installation
+
 [lazy.nvim](https://github.com/folke/lazy.nvim)
+
 ```lua
 {
     "ethanholz/freeze.nvim",
@@ -13,13 +13,23 @@ A tool for using [freeze](https://github.com/charmbracelet/freeze) right from Ne
 }
 ```
 
+> [!note]
+>
+> [freeze](https://github.com/charmbracelet/freeze) will get installed automatically.
+>
+> If you have [go](https://go.dev) installed it will use `go install github.com/charmbracelet/freeze@latest`.
+> Otherwise the binary will get installed in `$HOME/.local/bin`
+
 ## Usage
+
 - `:Freeze` - Can be called on a visual selection to pass in a selection of lines.
 - `:FreezeLine` - A convenience function for freezing the current line.
 
 ## Keymaps
-It is recommended that you set keymaps to run these commands, no default keymaps are set for you. 
+
+It is recommended that you set keymaps to run these commands, no default keymaps are set for you.
 An example of how you can set your keymaps can be seen below:
+
 ```lua
 vim.keymap.set("v", "<leader>z", ":Freeze<cr>", {silent = true, desc = "Freeze selection"})
 vim.keymap.set("n", "<leader>zl", ":FreezeLine<cr>", {silent = true, desc = "Freeze current line"})


### PR DESCRIPTION
# Motivation

I use [glow.nvim](https://github.com/ellisonleao/glow.nvim) and this plugin will install the binary directly instead of requiring it to use the plugin itself.

I took inspiration from that and improved it a bit, making it so it has an **agnostic** installation (independent from having [go](https://go.dev) installed or not, using the [releases page](https://github.com/charmbracelet/freeze/releases)), and a **go** installation (using `go install github.com/charmbracelet/freeze@latest`

## How it works

If the `freeze` command is not in the `PATH`, it will:

- Check for `go` command:
  - If in `PATH`, use it to install `freeze`
  - If not installed, use the [releases page](https://github.com/charmbracelet/freeze/releases) to download the latest stable version, depending on the **OS** and **Architecture** of the machine

## Conclusion

It will improve the user experience, not having to download the `cli` itself if they don't use **go**, and if they do, saving them time for the installation process.