### PR TITLE
feat(#5): add copying to clipboard support

### DIFF
--- a/lua/freeze/init.lua
+++ b/lua/freeze/init.lua
@@ -172,7 +172,7 @@ end
 ---@param filename string
 local function copy_unix(filename)
 	local cmd = {}
-  -- echo $XDG_SESSION_TYPE should show `x11` for X11 systems and `wayland` for Wayland systems
+	-- echo $XDG_SESSION_TYPE should show `x11` for X11 systems and `wayland` for Wayland systems
 	if vim.env.XDG_SESSION_TYPE == "wayland" then
 		if vim.fn.exepath("wl-copy") == "" then
 			vim.notify("`wl-copy` is not installed", vim.log.levels.ERROR, { title = "Freeze" })

--- a/lua/freeze/init.lua
+++ b/lua/freeze/init.lua
@@ -179,23 +179,19 @@ local function copy_macos(filename)
 	os.execute(table.concat(cmd, " "))
 end
 
----Copy command for Unix OS
+---Copy command for Mac OS
 ---@param filename string
-local function copy_unix(filename)
-	if vim.fn.exepath("xclip") == "" then
-		vim.notify("`xclip` is not installed", vim.log.levels.ERROR, { title = "Freeze" })
+local function copy_macos(filename)
+	if vim.fn.executable("xclip") == 1 then
+		copy_unix(filename)
 		return
 	end
 	local cmd = {
-		"xclip",
-		"-selection",
-		"clipboard",
-		"-t",
-		"image/png",
-		"-i",
-		filename,
+		"osascript",
+		"-e",
+		"'set the clipboard to (read (POSIX file \"" .. filename .. "\") as JPEG picture)'",
 	}
-  os.execute(table.concat(cmd, " "))
+	os.execute(table.concat(cmd, " "))
 end
 
 ---Copy the frozen frame to the clipboard

--- a/lua/freeze/init.lua
+++ b/lua/freeze/init.lua
@@ -168,14 +168,36 @@ local function copy_windows(filename)
 	os.execute(table.concat(cmd, " "))
 end
 
----Copy command for Mac OS
+---Copy command for Unix OS
 ---@param filename string
-local function copy_macos(filename)
-	local cmd = {
-		"osascript",
-		"-e",
-		"'set the clipboard to (read (POSIX file \"" .. filename .. "\") as JPEG picture)'",
-	}
+local function copy_unix(filename)
+	local cmd = {}
+  -- echo $XDG_SESSION_TYPE should show `x11` for X11 systems and `wayland` for Wayland systems
+	if vim.env.XDG_SESSION_TYPE == "wayland" then
+		if vim.fn.exepath("wl-copy") == "" then
+			vim.notify("`wl-copy` is not installed", vim.log.levels.ERROR, { title = "Freeze" })
+			return
+		end
+		cmd = {
+			"wl-copy",
+			"<",
+			filename,
+		}
+	else
+		if vim.fn.exepath("xclip") == "" then
+			vim.notify("`xclip` is not installed", vim.log.levels.ERROR, { title = "Freeze" })
+			return
+		end
+		cmd = {
+			"xclip",
+			"-selection",
+			"clipboard",
+			"-t",
+			"image/png",
+			"-i",
+			filename,
+		}
+	end
 	os.execute(table.concat(cmd, " "))
 end
 

--- a/lua/freeze/init.lua
+++ b/lua/freeze/init.lua
@@ -44,6 +44,10 @@ local function handleActions()
 	end
 	if freeze.opts.copy and freeze.output ~= nil then
 		freeze.copy(freeze.output)
+    if vim.v.shell_error ~= 0 then
+      vim.notify("Failed to copy to clipboard", vim.log.levels.ERROR, { title = "Freeze" })
+      return
+    end
 		local msg = string.format("frozen frame `%s` has been copied to the clipboard", freeze.output)
 		vim.notify(msg, vim.log.levels.INFO, { title = "Freeze" })
 	end
@@ -165,7 +169,7 @@ local function copy_windows(filename)
 		"System.Windows.Forms;",
 		'[Windows.Forms.Clipboard]::SetImage($([System.Drawing.Image]::FromFile("' .. filename .. '")))',
 	}
-	os.execute(table.concat(cmd, " "))
+	vim.fn.system(cmd)
 end
 
 ---Copy command for Unix OS
@@ -198,7 +202,7 @@ local function copy_unix(filename)
 			filename,
 		}
 	end
-	os.execute(table.concat(cmd, " "))
+	vim.fn.system(cmd)
 end
 
 ---Copy command for Mac OS
@@ -211,9 +215,9 @@ local function copy_macos(filename)
 	local cmd = {
 		"osascript",
 		"-e",
-		"'set the clipboard to (read (POSIX file \"" .. filename .. "\") as JPEG picture)'",
+		'set the clipboard to (read (POSIX file "' .. filename .. '") as {«class PNGf»})',
 	}
-	os.execute(table.concat(cmd, " "))
+	vim.fn.system(cmd)
 end
 
 ---Copy the frozen frame to the clipboard


### PR DESCRIPTION
- [X] Windows support
  - Using `powershell` script

`powershell` script demo from Windows11 VM:
<img width="Windows VM powershell script in action" src="https://github.com/ethanholz/freeze.nvim/assets/71392160/5a739fbd-80eb-40b8-85c2-bedeb625254f">

Image pasted from Windows11 VM:
![image from windows wm](https://github.com/ethanholz/freeze.nvim/assets/71392160/80837e9e-3cdd-400d-8603-62be399f0097)


- [X] MacOS support
  - Using `osascript`

`osascript` demo from MacOS:

```bash
osascript -e 'set the clipboard to (read (POSIX file "/Users/aome/dev/nvim_plugins/freeze.nvim/freeze.png") as JPEG picture)'
```

Image from the script:
![image from MacOS script](https://github.com/ethanholz/freeze.nvim/assets/71392160/08b3c6b3-3ac2-495e-bbe4-b7dbe62550e2)

- [x] Unix like support
  - Using `xclip`

I didn't test it yet in Ubuntu, but the script looks fine from what I use to copy images myself. If `xclip` is not the way to do it, I will appreciate some suggestions.

Closes #5