### PR TITLE
feat(#8): added linting and formatting rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+end_of_file = "lf"
+trim_trailing_whitespace = true
+insert_final_newline = false
+
+[Makefile]
+indent_style = tab
+indent_size = 4
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+# This makes it a lot less painful to write YAMLs in docs
+[*.md]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,42 @@
+name: lint
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "lua/**/*.lua"
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+    paths:
+      - "lua/**/*.lua"
+
+jobs:
+  lint:
+    name: Selene check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Run selene
+        uses: NTBBloodbath/selene-action@v1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --display-style quiet lua/freeze
+
+  style-lint:
+    name: Stylua check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Lint with stylua
+        uses: JohnnyMorganz/stylua-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
+          args: --color always --check .

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ lint-all: lint style-lint
 
 format:
 	@printf "\nFormatting with stylua\n"
-	@stylua --color always
+	@stylua --color always .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: lint style-lint lint-all
+
+lint:
+	@printf "\nRunning selene\n"
+	@selene --display-style quiet lua/freeze
+
+style-lint:
+	@printf "\nRunning stylua\n"
+	@stylua --color always --check .
+
+lint-all: lint style-lint
+
+format:
+	@printf "\nFormatting with stylua\n"
+	@stylua --color always

--- a/lua/freeze/init.lua
+++ b/lua/freeze/init.lua
@@ -2,14 +2,14 @@ local loop = vim.loop
 local default_output = "freeze.png"
 
 local freeze = {
-	opts = {
-		dir = ".",
-		output = default_output,
-		theme = "default",
-		config = "base",
-		open = false,
-	},
-	output = nil,
+  opts = {
+    dir = ".",
+    output = default_output,
+    theme = "default",
+    config = "base",
+    open = false,
+  },
+  output = nil,
 }
 local stdio = { stdout = "", stderr = "" }
 
@@ -17,28 +17,28 @@ local stdio = { stdout = "", stderr = "" }
 ---@param err any the possible err we received
 ---@param data any the possible data we received in stdout
 local function onReadStdOut(err, data)
-	if err then
-		vim.notify(err, vim.log.levels.ERROR, { title = "Freeze" })
-	end
-	if data then
-		stdio.stdout = stdio.stdout .. data
-	end
-	if freeze.opts.open and freeze.output ~= nil then
-		freeze.open(freeze.output)
-		freeze.output = nil
-	end
+  if err then
+    vim.notify(err, vim.log.levels.ERROR, { title = "Freeze" })
+  end
+  if data then
+    stdio.stdout = stdio.stdout .. data
+  end
+  if freeze.opts.open and freeze.output ~= nil then
+    freeze.open(freeze.output)
+    freeze.output = nil
+  end
 end
 
 ---The callback for reading stderr.
 ---@param err any the possible err we received
 ---@param data any the possible data we received in stderr
 local function onReadStdErr(err, data)
-	if err then
-		vim.notify(err, vim.log.levels.ERROR, { title = "Freeze" })
-	end
-	if data then
-		stdio.stderr = stdio.stderr .. data
-	end
+  if err then
+    vim.notify(err, vim.log.levels.ERROR, { title = "Freeze" })
+  end
+  if data then
+    stdio.stderr = stdio.stderr .. data
+  end
 end
 
 ---The function called on exit of from the event loop
@@ -46,17 +46,17 @@ end
 ---@param stderr any the stderr pipe used by vim.loop
 ---@return function cb the wrapped schedule function callback
 local function onExit(stdout, stderr)
-	return vim.schedule_wrap(function(code, _)
-		if code == 0 then
-			vim.notify("Successfully frozen 🍦", vim.log.levels.INFO, { title = "Freeze" })
-		else
-			vim.notify(stdio.stdout, vim.log.levels.ERROR, { title = "Freeze" })
-		end
-		stdout:read_stop()
-		stderr:read_stop()
-		stdout:close()
-		stderr:close()
-	end)
+  return vim.schedule_wrap(function(code, _)
+    if code == 0 then
+      vim.notify("Successfully frozen 🍦", vim.log.levels.INFO, { title = "Freeze" })
+    else
+      vim.notify(stdio.stdout, vim.log.levels.ERROR, { title = "Freeze" })
+    end
+    stdout:read_stop()
+    stderr:read_stop()
+    stdout:close()
+    stderr:close()
+  end)
 end
 
 --- The main function used for passing the main config to lua
@@ -66,103 +66,103 @@ end
 --- @param start_line number the starting line to pass to freeze
 --- @param end_line number the ending line to pass to freeze
 function freeze.freeze(start_line, end_line)
-	if vim.fn.executable("freeze") ~= 1 then
-		vim.notify("`freeze` not found!", vim.log.levels.WARN, { title = "Freeze" })
-		return
-	end
+  if vim.fn.executable("freeze") ~= 1 then
+    vim.notify("`freeze` not found!", vim.log.levels.WARN, { title = "Freeze" })
+    return
+  end
 
-	local language = vim.api.nvim_buf_get_option(0, "filetype")
-	local file = vim.api.nvim_buf_get_name(0)
-	local config = freeze.opts.config
-	local dir = freeze.opts.dir
-	local stdout = loop.new_pipe(false)
-	local stderr = loop.new_pipe(false)
-	local output = freeze.opts.output
+  local language = vim.api.nvim_buf_get_option(0, "filetype")
+  local file = vim.api.nvim_buf_get_name(0)
+  local config = freeze.opts.config
+  local dir = freeze.opts.dir
+  local stdout = loop.new_pipe(false)
+  local stderr = loop.new_pipe(false)
+  local output = freeze.opts.output
 
-	if freeze.opts.output ~= default_output then
-		local timestamp = os.date("%Y%m%d%H%M%S")
-		local filename = file:match("^.+/(.+)$") or file
+  if freeze.opts.output ~= default_output then
+    local timestamp = os.date("%Y%m%d%H%M%S")
+    local filename = file:match("^.+/(.+)$") or file
 
-		output = output:gsub("{timestamp}", timestamp)
-		output = output:gsub("{filename}", filename)
-		output = output:gsub("{start_line}", start_line)
-		output = output:gsub("{end_line}", end_line)
-	end
+    output = output:gsub("{timestamp}", timestamp)
+    output = output:gsub("{filename}", filename)
+    output = output:gsub("{start_line}", start_line)
+    output = output:gsub("{end_line}", end_line)
+  end
 
-	freeze.output = dir .. "/" .. output
+  freeze.output = dir .. "/" .. output
 
-	local handle = loop.spawn("freeze", {
-		args = {
-			"--output",
-			freeze.output,
-			"--language",
-			language,
-			"--lines",
-			start_line .. "," .. end_line,
-			"--config",
-			config,
-			"--theme",
-			freeze.opts.theme,
-			file,
-		},
-		stdio = { nil, stdout, stderr },
-	}, onExit(stdout, stderr))
-	if not handle then
-		vim.notify("Failed to spawn freeze", vim.log.levels.ERROR, { title = "Freeze" })
-	end
-	if stdout ~= nil then
-		loop.read_start(stdout, onReadStdOut)
-	end
-	if stderr ~= nil then
-		loop.read_start(stderr, onReadStdErr)
-	end
+  local handle = loop.spawn("freeze", {
+    args = {
+      "--output",
+      freeze.output,
+      "--language",
+      language,
+      "--lines",
+      start_line .. "," .. end_line,
+      "--config",
+      config,
+      "--theme",
+      freeze.opts.theme,
+      file,
+    },
+    stdio = { nil, stdout, stderr },
+  }, onExit(stdout, stderr))
+  if not handle then
+    vim.notify("Failed to spawn freeze", vim.log.levels.ERROR, { title = "Freeze" })
+  end
+  if stdout ~= nil then
+    loop.read_start(stdout, onReadStdOut)
+  end
+  if stderr ~= nil then
+    loop.read_start(stderr, onReadStdErr)
+  end
 end
 
 --- Opens the last created image in macOS using `open`.
 --- @param filename string the filename to open
 function freeze.open(filename)
-	if vim.fn.executable("open") ~= 1 then
-		vim.notify("`open` not found!", vim.log.levels.WARN, { title = "Freeze" })
-		return
-	end
+  if vim.fn.executable("open") ~= 1 then
+    vim.notify("`open` not found!", vim.log.levels.WARN, { title = "Freeze" })
+    return
+  end
 
-	local stdout = loop.new_pipe(false)
-	local stderr = loop.new_pipe(false)
-	local handle = loop.spawn("open", {
-		args = {
-			filename,
-		},
-		stdio = { nil, stdout, stderr },
-	}, onExit(stdout, stderr))
-	if not handle then
-		vim.notify("Failed to spawn freeze", vim.log.levels.ERROR, { title = "Freeze" })
-	end
-	if stdout ~= nil then
-		loop.read_start(stdout, onReadStdOut)
-	end
-	if stderr ~= nil then
-		loop.read_start(stderr, onReadStdErr)
-	end
+  local stdout = loop.new_pipe(false)
+  local stderr = loop.new_pipe(false)
+  local handle = loop.spawn("open", {
+    args = {
+      filename,
+    },
+    stdio = { nil, stdout, stderr },
+  }, onExit(stdout, stderr))
+  if not handle then
+    vim.notify("Failed to spawn freeze", vim.log.levels.ERROR, { title = "Freeze" })
+  end
+  if stdout ~= nil then
+    loop.read_start(stdout, onReadStdOut)
+  end
+  if stderr ~= nil then
+    loop.read_start(stderr, onReadStdErr)
+  end
 end
 
 --- Setup function for enabling both user commands.
 --- Sets up :Freeze for freezing a selection and :FreezeLine
 --- to freeze a single line.
 function freeze.setup(plugin_opts)
-	for k, v in pairs(plugin_opts) do
-		freeze.opts[k] = v
-	end
-	vim.api.nvim_create_user_command("Freeze", function(opts)
-		if opts.count > 0 then
-			freeze.freeze(opts.line1, opts.line2)
-		else
-			freeze.freeze(1, vim.api.nvim_buf_line_count(0))
-		end
-	end, { range = true })
-	vim.api.nvim_create_user_command("FreezeLine", function(_)
-		local line = vim.api.nvim_win_get_cursor(0)[1]
-		freeze.freeze(line, line)
-	end, {})
+  for k, v in pairs(plugin_opts) do
+    freeze.opts[k] = v
+  end
+  vim.api.nvim_create_user_command("Freeze", function(opts)
+    if opts.count > 0 then
+      freeze.freeze(opts.line1, opts.line2)
+    else
+      freeze.freeze(1, vim.api.nvim_buf_line_count(0))
+    end
+  end, { range = true })
+  vim.api.nvim_create_user_command("FreezeLine", function(_)
+    local line = vim.api.nvim_win_get_cursor(0)[1]
+    freeze.freeze(line, line)
+  end, {})
 end
 
 return freeze

--- a/neovim.yml
+++ b/neovim.yml
@@ -1,0 +1,27 @@
+---
+base: lua51
+
+globals:
+  jit:
+    any: true
+  vim:
+    any: true
+  assert:
+    args:
+      - type: bool
+      - type: string
+        required: false
+  after_each:
+    args:
+      - type: function
+  before_each:
+    args:
+      - type: function
+  describe:
+    args:
+      - type: string
+      - type: function
+  it:
+    args:
+      - type: string
+      - type: function

--- a/selene.toml
+++ b/selene.toml
@@ -1,0 +1,8 @@
+std="neovim" # read from `neovim.yml`
+
+[rules]
+global_usage = "warn"
+multiple_statements = "allow"
+incorrect_standard_library_use = "allow"
+mixed_table = "allow"
+unused_variable = "warn"

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,10 @@
+column_width = 120
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferDouble"
+call_parentheses = "Always"
+collapse_simple_statement = "Never"
+
+[sort_requires]
+enabled = true


### PR DESCRIPTION
As explained in #8, I added `selene` and `stylua` for linting and formatting **lua** files and
`editorconfig` for more general linting rules of the rest of the files, example: `.md`, `.yml`, etc. files.

The `Makefile` addition is for easy to use `make lint`, `make style-lint`, `make lint-all` and `make format` (to apply the fixes with stylua).

Added the workflow to use `selene` and `stylua` on push and pull_request targeting the `main` branch, and only when `lua/**/*.lua` files are modified.

Closes #8.