### PR TITLE
feat(#12): added `:checkhealth freeze` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A tool for using [freeze](https://github.com/charmbracelet/freeze) right from Ne
 ## Requirements
 - [freeze](https://github.com/charmbracelet/freeze) must be installed and on your path
 
+> [!note]
+>
+> You can check all the dependencies by running `:checkhealth freeze` on NeoVim.
+
 ## Installation
 [lazy.nvim](https://github.com/folke/lazy.nvim)
 ```lua
@@ -18,7 +22,7 @@ A tool for using [freeze](https://github.com/charmbracelet/freeze) right from Ne
 - `:FreezeLine` - A convenience function for freezing the current line.
 
 ## Keymaps
-It is recommended that you set keymaps to run these commands, no default keymaps are set for you. 
+It is recommended that you set keymaps to run these commands, no default keymaps are set for you.
 An example of how you can set your keymaps can be seen below:
 ```lua
 vim.keymap.set("v", "<leader>z", ":Freeze<cr>", {silent = true, desc = "Freeze selection"})

--- a/autload/health/freeze.vim
+++ b/autload/health/freeze.vim
@@ -1,0 +1,3 @@
+function! health#freeze#check()
+  lua require("freeze.health").check()
+endfunction

--- a/lua/freeze/health.lua
+++ b/lua/freeze/health.lua
@@ -1,0 +1,208 @@
+local health = vim.health or require("health")
+
+local report_start = health.start or health.report_start
+local report_ok = health.ok or health.report_ok
+local report_warn = health.warn or health.report_warn
+local report_error = health.error or health.report_error
+
+local is_win = vim.api.nvim_call_function("has", { "win32" }) == 1
+local is_macos = vim.api.nvim_call_function("has", { "macunix" }) == 1
+local is_linux = vim.api.nvim_call_function("has", { "unix" }) == 1
+
+---@alias os_platform "windows"|"macos"|"linux"|"all"
+
+---@class FreezeCodeHealthPackage
+---@field name string: package name
+---@field cmd string[]: cmd command call
+---@field url string: package url
+---@field optional boolean: whether or not is an optional package
+---@field args string[]|nil: check version command
+---@field platform os_platform: for which OS is needed
+
+---@class FreezeCodeHealthDependency
+---@field cmd_name string: command name
+---@table package FreezeCodeHealthPackage[]
+
+---@type FreezeCodeHealthDependency[]
+local optional_dependencies = {
+	{
+		cmd_name = "freeze",
+		package = {
+			{
+				name = "Freeze",
+				cmd = { "freeze" },
+				args = nil,
+				url = "[charmbracelet/freeze](https://github.com/charmbracelet/freeze)",
+				optional = false,
+				platform = "all",
+			},
+		},
+	},
+	{
+		cmd_name = "osascript",
+		package = {
+			{
+				name = "Osascript",
+				cmd = { "osascript" },
+				args = nil,
+				url = "[docs](https://pypi.org/project/osascript/)",
+				optional = true,
+				platform = "macos",
+			},
+		},
+	},
+	{
+		cmd_name = "xclip",
+		package = {
+			{
+				name = "xclip",
+				cmd = { "xclip" },
+				args = nil,
+				url = "[astrand/xclip](https://github.com/astrand/xclip)",
+				optional = true,
+				platform = "linux",
+			},
+		},
+	},
+	{
+		cmd_name = "Add-Type",
+		package = {
+			name = "powershell",
+			cmd = { "pwsh" },
+			args = { "--version" },
+			url = "[PowerShell/PowerShell](https://github.com/PowerShell/PowerShell)",
+			optional = true,
+			platform = "windows",
+		},
+	},
+	{
+		cmd_name = "open",
+		package = {
+			name = "Open",
+			cmd = { "open" },
+			args = nil,
+			url = "[docs](https://www.man7.org/linux/man-pages/man2/open.2.html)",
+			optional = true,
+			platform = "linux",
+		},
+	},
+	{
+		cmd_name = "explorer",
+		package = {
+			name = "Open",
+			cmd = { "explorer" },
+			args = nil,
+			url = "[docs](https://devblogs.microsoft.com/scripting/use-powershell-to-work-with-windows-explorer/)",
+			optional = true,
+			platform = "windows",
+		},
+	},
+}
+
+---Check if the package is needed by the platorm
+---@param pkg FreezeCodeHealthPackage
+---@retur boolean
+local check_platform_needed = function(pkg)
+	if pkg.platform == "windows" then
+		return is_win
+	end
+	if pkg.platform == "linux" or pkg.platform == "macos" then
+		return is_linux or is_macos
+	end
+	if pkg.platform == "linux" then
+		return is_linux
+	end
+	if pkg.platform == "macos" then
+		return is_macos
+	end
+
+	return true
+end
+
+---Check if the cmd for the package are installed and which version
+---@param pkg FreezeCodeHealthPackage
+---@return boolean installed
+---@return string|any
+---@return boolean needed
+local check_binary_installed = function(pkg)
+	local needed = check_platform_needed(pkg)
+	local cmd = pkg.cmd or { pkg.name }
+	for _, binary in ipairs(cmd) do
+		if is_win then
+			binary = binary .. ".exe"
+		end
+		if vim.fn.executable(binary) == 1 then
+			local binary_version = ""
+			local version_cmd = ""
+			if pkg.args == nil then
+				return vim.fn.executable(binary) == 1, "", needed
+			else
+				local cmd_args = table.concat(pkg.args, " ")
+				version_cmd = table.concat({ binary, cmd_args }, " ")
+			end
+			local handle, err = io.popen(version_cmd)
+
+			if err then
+				report_error(err)
+				vim.notify(err, vim.log.levels.ERROR, { title = "Freeze" })
+				return true, err, needed
+			end
+			if handle then
+				binary_version = handle:read("*a")
+				handle:close()
+				if
+					binary_version:lower():find("illegal")
+					or binary_version:lower():find("unknown")
+					or binary_version:lower():find("invalid")
+				then
+					return true, "", needed
+				end
+				return true, binary_version, needed
+			end
+		end
+	end
+	return false, "", needed
+end
+
+local M = {}
+
+M.check = function()
+	report_start("Checking for external dependencies")
+
+	for _, opt_dep in pairs(optional_dependencies) do
+		for _, pkg in ipairs(opt_dep.package) do
+			local installed, version, needed = check_binary_installed(pkg)
+			if not installed then
+				local err_msg = string.format("%s: not found.", pkg.name)
+				if pkg.optional and needed then
+					local warn_msg =
+						string.format("%s %s", err_msg, string.format("Install %s for extended capabilities", pkg.url))
+					report_warn(warn_msg)
+				else
+					if needed then
+						err_msg = string.format(
+							"%s %s",
+							err_msg,
+							string.format("`%s` will not function without %s installed.", opt_dep.cmd_name, pkg.url)
+						)
+						report_error(err_msg)
+					end
+				end
+			else
+				if version ~= "not needed" then
+					version = version == "" and "(unkown)" or version
+					local eol = version:find("\n")
+					if eol == nil then
+						version = "(unkown)"
+					else
+						version = version:sub(0, eol - 1)
+					end
+					local ok_msg = string.format("%s: found! version: `%s`", pkg.name, version)
+					report_ok(ok_msg)
+				end
+			end
+		end
+	end
+end
+
+return M

--- a/lua/freeze/init.lua
+++ b/lua/freeze/init.lua
@@ -152,17 +152,6 @@ function freeze.setup(plugin_opts)
 	for k, v in pairs(plugin_opts) do
 		freeze.opts[k] = v
 	end
-	vim.api.nvim_create_user_command("Freeze", function(opts)
-		if opts.count > 0 then
-			freeze.freeze(opts.line1, opts.line2)
-		else
-			freeze.freeze(1, vim.api.nvim_buf_line_count(0))
-		end
-	end, { range = true })
-	vim.api.nvim_create_user_command("FreezeLine", function(_)
-		local line = vim.api.nvim_win_get_cursor(0)[1]
-		freeze.freeze(line, line)
-	end, {})
 end
 
 return freeze

--- a/plugin/freeze.lua
+++ b/plugin/freeze.lua
@@ -1,0 +1,11 @@
+-- if vim.fn.has("nvim-0.8.0") ~= 1 then
+--   vim.api.nvim_err_writeln("[freeze] plugin requires at least NeoVim 0.8.0.")
+--   return
+-- end
+
+-- Check if plugin is loaded
+if vim.g.loaded_freeze_nvim == 1 then
+  return
+end
+vim.g.loaded_freeze_nvim = 1
+vim.api.nvim_out_write("[freeze] initialized")

--- a/plugin/freeze.lua
+++ b/plugin/freeze.lua
@@ -1,11 +1,32 @@
--- if vim.fn.has("nvim-0.8.0") ~= 1 then
---   vim.api.nvim_err_writeln("[freeze] plugin requires at least NeoVim 0.8.0.")
---   return
--- end
+if vim.fn.has("nvim-0.8.0") ~= 1 then
+	local current = vim.version()
+	local msg = string.format(
+		"[freeze.nvim] ERROR: this plugin requires at least NeoVim v0.8.0, your current version is v%s.%s.%s",
+		current.major,
+		current.minor,
+		current.patch
+	)
+	vim.api.nvim_err_writeln(msg)
+	return
+end
 
 -- Check if plugin is loaded
 if vim.g.loaded_freeze_nvim == 1 then
-  return
+	return
 end
 vim.g.loaded_freeze_nvim = 1
-vim.api.nvim_out_write("[freeze] initialized")
+vim.api.nvim_out_write("[freeze.nvim] initialized")
+
+local freeze = require("freeze")
+
+vim.api.nvim_create_user_command("Freeze", function(opts)
+	if opts.count > 0 then
+		freeze.freeze(opts.line1, opts.line2)
+	else
+		freeze.freeze(1, vim.api.nvim_buf_line_count(0))
+	end
+end, { range = true })
+vim.api.nvim_create_user_command("FreezeLine", function(_)
+	local line = vim.api.nvim_win_get_cursor(0)[1]
+	freeze.freeze(line, line)
+end, {})


### PR DESCRIPTION
Now we can `:checkhealth` or `:checkhealth freeze` when the plugin is loaded to get the information about dependencies for the plugin.

All required dependencies installed:

<img width="921" alt=":checkhealth freeze green pass" src="https://github.com/ethanholz/freeze.nvim/assets/71392160/6d5ed642-969f-4e26-873b-f27607b7f218">

Missing required dependency `freeze`:

<img width="1094" alt=":checkhealth freeze required freeze not installed" src="https://github.com/ethanholz/freeze.nvim/assets/71392160/ef108eba-4947-43d3-b4d0-1cba4474b2c4">

- [x] checkhealth command
- [x] autoload checkhealth
- [x] plugin folder for requirements, it can be modified to alert if NeoVim version is lower than the APIs that we use, I think `v0.8.0` is fine, but lower I think some are deprecated or not functioning.