### PR TITLE
feat: added support for nvim v0.10.0 deprecated API

### DIFF
--- a/lua/freeze/init.lua
+++ b/lua/freeze/init.lua
@@ -71,7 +71,12 @@ function freeze.freeze(start_line, end_line)
 		return
 	end
 
-	local language = vim.api.nvim_buf_get_option(0, "filetype")
+  local language = ""
+  if vim.version().minor >= 10 then
+    language = vim.api.nvim_get_option_value("filetype", { scope = "local", buf = vim.api.nvim_get_current_buf() })
+  else
+	  language = vim.api.nvim_buf_get_option(0, "filetype")
+  end
 	local file = vim.api.nvim_buf_get_name(0)
 	local config = freeze.opts.config
 	local dir = freeze.opts.dir

--- a/lua/freeze/init.lua
+++ b/lua/freeze/init.lua
@@ -73,7 +73,7 @@ function freeze.freeze(start_line, end_line)
 
   local language = ""
   if vim.version().minor >= 10 then
-    language = vim.api.nvim_get_option_value("filetype", { scope = "local", buf = vim.api.nvim_get_current_buf() })
+    language = vim.api.nvim_get_option_value("filetype", { buf = vim.api.nvim_get_current_buf() })
   else
 	  language = vim.api.nvim_buf_get_option(0, "filetype")
   end


### PR DESCRIPTION
# Changes made

- [x] If the version is v0.10.0 or higher use the new API.

`vim.api.nvim_win_set_option` and `vim.api.nvim_buf_set_option` are combined into `vim.api.nvim_set_option_value` from v0.10.0 onwards.

## Reference

- [Deprecated API changes from v0.10.0 onwards](https://neovim.io/doc/user/deprecated.html#deprecated-0.10)